### PR TITLE
Link logo for favicon

### DIFF
--- a/hipposerve/web/templates/core.html
+++ b/hipposerve/web/templates/core.html
@@ -4,6 +4,7 @@
     <meta charset="utf-8">
     <meta name="viewport" content="width=device-width, initial-scale=1">
     <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/css/bootstrap.min.css" rel="stylesheet" integrity="sha384-QWTKZyjpPEjISv5WaRU9OFeRpok6YctnYmDr5pNlyT2bRjXh0JMhjY6hW+ALEwIH" crossorigin="anonymous">
+    <link id="favicon" rel="icon" type="image/x-icon" href="/web/static/logo.svg">
     <title>Simons Observatory Post Office</title>
   </head>
   <style>


### PR DESCRIPTION
A trivial one-liner to use the logo as the browser's favicon.