### PR TITLE
Add exception handlers

### DIFF
--- a/hipposerve/web/templates/404.html
+++ b/hipposerve/web/templates/404.html
@@ -1,0 +1,9 @@
+{% extends "core.html" %}
+{% block content %}
+<div class="container-fluid fs-base">
+    <h2>Page Not Found</h2>
+    {% if error_details.type != 'generic' %}
+        <p>A <span class="fw-bold">{{error_details.type}}</span> with ID <span class="fw-bold">{{error_details.requested_id}}</span> does not exist.</p>
+    {% endif %}
+</div>
+{% endblock %}


### PR DESCRIPTION
Closes #38

I registered some exception handlers that will serve a `404.html` template. Note that the `validation_exception_handler` basically assumes we're only getting validation errors from improper collection/product IDs, which is probably not the safest assumption but maybe fine for now?