### PR TITLE
Parent child UI

### DIFF
--- a/examples/recursive_collection/simplepopulate.py
+++ b/examples/recursive_collection/simplepopulate.py
@@ -3,6 +3,8 @@ An extremely simple example that creates two collections, one which is a child
 collection of the other.
 """
 
+import random
+
 from hippoclient import Client
 from hippoclient.collections import create as create_collection
 from hippoclient.relationships import add_child_collection
@@ -10,19 +12,70 @@ from hippoclient.relationships import add_child_collection
 API_KEY = "TEST_API_KEY"
 SERVER_LOCATION = "http://127.0.0.1:8000"
 
+
+def parent_child_collection_generator(
+    parent_id, parent_name, number_of_children, generate_grandchildren
+):
+    for n in range(1, number_of_children + 1):
+        child_id = create_collection(
+            client=client,
+            name=f"Child {n} of {parent_name}",
+            description=f"This is child {n} of {parent_name}",
+        )
+
+        if generate_grandchildren:
+            # randomly generate grandchildren at a 50% rate per collection
+            if random.randint(0, 1) == 0:
+                # randomly generate a number of grandchildren between 1 and 3
+                num_grandchildren = random.randint(1, 3)
+                for ng in range(num_grandchildren):
+                    grandchild_id = create_collection(
+                        client=client,
+                        name=f"Grandchild {ng + 1} of Child {n}",
+                        description="",
+                    )
+                    add_child_collection(
+                        client=client, parent=child_id, child=grandchild_id
+                    )
+
+        add_child_collection(client=client, parent=parent_id, child=child_id)
+
+
 if __name__ == "__main__":
     client = Client(api_key=API_KEY, host=SERVER_LOCATION, verbose=True)
 
-    child = create_collection(
+    parent_id_1 = create_collection(
         client=client,
-        name="Child Collection",
-        description="This is a child collection",
+        name="Parent Collection with One Child",
+        description="This is a parent collection with one child",
+    )
+    parent_child_collection_generator(
+        parent_id=parent_id_1,
+        parent_name="Parent Collection with One Child",
+        number_of_children=1,
+        generate_grandchildren=True,
     )
 
-    parent = create_collection(
+    parent_id_2 = create_collection(
         client=client,
-        name="Parent Collection",
-        description="This is a parent collection",
+        name="Parent Collection with Five Child",
+        description="This is a parent collection with five child",
+    )
+    parent_child_collection_generator(
+        parent_id=parent_id_2,
+        parent_name="Parent Collection with Five Children",
+        number_of_children=5,
+        generate_grandchildren=True,
     )
 
-    add_child_collection(client=client, parent=parent, child=child)
+    parent_id_3 = create_collection(
+        client=client,
+        name="Parent Collection with Seven Child",
+        description="This is a parent collection with seven child",
+    )
+    parent_child_collection_generator(
+        parent_id=parent_id_3,
+        parent_name="Parent Collection with Seven Children",
+        number_of_children=7,
+        generate_grandchildren=False,
+    )

--- a/hippoclient/relationships.py
+++ b/hippoclient/relationships.py
@@ -103,7 +103,7 @@ def add_child_collection(client: Client, parent: str, child: str) -> bool:
         If a request to the API fails
     """
 
-    response = client.put(f"/relationships/collection/{child}/child_of/{parent}")
+    response = client.put(f"/relationships/collection/{parent}/child_of/{child}")
 
     response.raise_for_status()
 

--- a/hipposerve/web/__init__.py
+++ b/hipposerve/web/__init__.py
@@ -62,7 +62,6 @@ async def collection_view(
     request: Request, id: PydanticObjectId, user: PotentialLoggedInUser
 ):
     collection_instance = await collection.read(id)
-
     return templates.TemplateResponse(
         "collection.html",
         {"request": request, "collection": collection_instance, "user": user},

--- a/hipposerve/web/__init__.py
+++ b/hipposerve/web/__init__.py
@@ -6,9 +6,12 @@ NOTE: Code coverage is an explicit NON-goal for the web
       coverage metrics.
 """
 
+from typing import Literal
+
 from beanie import PydanticObjectId
 from fastapi import Request
 
+from hipposerve.database import Collection
 from hipposerve.service import collection, product
 from hipposerve.settings import SETTINGS
 
@@ -20,6 +23,17 @@ from .search import router as search_router
 
 web_router.include_router(search_router)
 web_router.include_router(auth_router)
+
+
+def get_overflow_content(lst: list[Collection], type: Literal["collection", "product"]):
+    if len(lst) < 6:
+        return None
+
+    overflow_content = ""
+    for n in range(6, len(lst) + 1):
+        overflow_content += f'<a href="{SETTINGS.web_root}/{type}s/{lst[n - 1].id}">{lst[n - 1].name}</a><br>'
+
+    return overflow_content
 
 
 @web_router.get("/")
@@ -65,11 +79,19 @@ async def collection_view(
     request: Request, id: PydanticObjectId, user: PotentialLoggedInUser
 ):
     collection_instance = await collection.read(id)
+    parents_overflow_content = get_overflow_content(
+        collection_instance.parent_collections, "collection"
+    )
+    children_overflow_content = get_overflow_content(
+        collection_instance.child_collections, "collection"
+    )
     return templates.TemplateResponse(
         "collection.html",
         {
             "request": request,
             "collection": collection_instance,
+            "parents_overflow_content": parents_overflow_content,
+            "children_overflow_content": children_overflow_content,
             "user": user,
             "web_root": SETTINGS.web_root,
         },

--- a/hipposerve/web/router.py
+++ b/hipposerve/web/router.py
@@ -8,7 +8,8 @@ from fastapi.templating import Jinja2Templates
 
 web_router = APIRouter(prefix="/web")
 
-potential_routes = ["", "hippo/"]
+# potential_routes = ["", "hippo/"]
+potential_routes = [""]
 
 for route in potential_routes:
     try:

--- a/hipposerve/web/templates/collection.html
+++ b/hipposerve/web/templates/collection.html
@@ -36,137 +36,14 @@
         </table>
     </div>
     {% if collection.parent_collections | length > 0 or collection.child_collections | length > 0 %}
-    {% set collection_dependencies = [collection.child_collections, collection.parent_collections] %}
     <div class="row">
         <h3>Collections</h3>
-        {% set parent_collections_t = [{"name": "parent a", "id": 100}] %}
-        {% set child_collections_t = [
-            {"name": "short", "id": 1},
-            {"name": "blah blah blah blah blah", "id": 2},
-            {"name": "this is poorly named", "id": 3},
-            {"name": "the golden child, if you will", "id": 4},
-            {"name": "child 5", "id": 5},
-            {"name": "child 6", "id": 6},
-            {"name": "child 7", "id": 7},
-        ] %}
-        {% set parent_collections = collection.parent_collections %}
-        {% set child_collections = collection.child_collections %}
-        {% set parent_length = parent_collections|length %}
-        {% set child_length = child_collections|length %}
-        {% set max_svg_width = 750 %}
-        {% set svg_width = ((parent_length if parent_length > child_length else child_length) * 125) if (parent_length < 6 and child_length < 6) else max_svg_width %}
-        {% set svg_height = 250 %}
-        {% set max_index_for_spacing = 6 %}
-        {% set y_adjustment = 0 if parent_length else 50 %}
-        <svg width="{{ svg_width }}" height="{{ svg_height }}">
-            <defs>
-                <marker 
-                  id='head' 
-                  orient="auto" 
-                  markerWidth='3' 
-                  markerHeight='4' 
-                  refX='0.1' 
-                  refY='2'
-                >
-                  <path d='M0,0 V4 L2,2 Z' fill="black" />
-                </marker>
-            </defs>
-            {% if parent_length %}
-                <!-- There can only be one parent -->
-                {% for index in range(parent_length) %}
-                    <text
-                        text-anchor="middle"
-                        x="{{ svg_width / 2 }}"
-                        y="15"
-                        data-bs-toggle="tooltip"
-                        title="{{ parent_collections[index].name }}"
-                    >
-                        <a href="{{ web_root }}/collections/{{parent_collections[index].id | e}}">{{parent_collections[index].name|truncate(11, True)}}</a>
-                    </text>
-                {% endfor %}
-                <path
-                    id='arrow-line'
-                    marker-end='url(#head)'
-                    stroke-width='2'
-                    fill='none'
-                    stroke='black'
-                    d="M{{ svg_width / 2 }},25, {{svg_width / 2}},50"
-                />
-            {% endif %}
-            <circle 
-                fill="#198754"
-                r="4"
-                cx="{{svg_width / 2 - 45}}"
-                cy="{{65 - y_adjustment}}"
-                data-bs-toggle="tooltip"
-                title="You are currently viewing this collection"
-            />
-            <text
-                text-anchor="middle"
-                x="{{ svg_width / 2 }}"
-                y="{{70 - y_adjustment }}"
-                data-bs-toggle="tooltip"
-                title="{{ collection.name }}"
-                class="fw-bold"
-                >{{collection.name|truncate(11, True)}}</text>
-            {% if child_length %}
-                {% if child_length != 1 %}
-                <path
-                    stroke-width="2"
-                    stroke="black"
-                    d="M{{ svg_width / 2 }},{{75 - y_adjustment}}, {{ svg_width / 2}},{{100 - y_adjustment}}"
-                />
-                {% endif %}
-                {% set y2_adjustment = y_adjustment if child_length > 1 else (y_adjustment + 20) %}
-                {% set dx_divisor = (max_index_for_spacing if child_length >= (max_index_for_spacing + 1) else child_length) + 1 %}
-                {% set dx_divisor_t = 7 %}
-                {% for index in range(child_length) if index <= 5 %}
-                    <path
-                        stroke-width="2"
-                        stroke="black"
-                        d="M{{ svg_width / 2 }},{{100 - y2_adjustment}} {{ ( svg_width / (dx_divisor) ) * (index + 1) }},{{100 - y2_adjustment}}"
-                    />
-                    <path
-                        id='arrow-line'
-                        marker-end='url(#head)'
-                        stroke-width='2'
-                        fill='none'
-                        stroke='black'
-                        d="M{{ ( svg_width / (dx_divisor) ) * (index + 1) }},{{99 - y2_adjustment}}, {{ ( svg_width / (dx_divisor) ) * (index + 1) }},{{120 - y2_adjustment}}"
-                    />
-                    {% if index <= 4 %}
-                        <text
-                            text-anchor="middle"
-                            x="{{ ( svg_width / (dx_divisor) ) * (index + 1) }}"
-                            y="{{140 - y2_adjustment}}"
-                            data-bs-toggle="tooltip"
-                            title="{{ child_collections[index].name }}"
-                        >
-                            <a href="{{ web_root }}/collections/{{child_collections[index].id | e}}">{{child_collections[index].name|truncate(11, True)}}</a>
-                        </text>
-                    {% endif %}
-                {% endfor %}
-                {% if child_length > 5 %}
-                    {% set remaining_children = [] %}
-                    {% for index in range(5, child_length) %}
-                        {% set _ = remaining_children.append(child_collections[index].id|e + "__id|name__" + child_collections[index].name + "__child|separator__") %}
-                    {% endfor %}
-                    <text
-                        text-anchor="middle"
-                        x="{{ ( svg_width / (dx_divisor) ) * (max_index_for_spacing) }}"
-                        y="{{140 - y2_adjustment}}"
-                        id="remaining-children-popover-trigger"
-                        data-remaining-children="{{''.join(remaining_children)}}"
-                        >
-                        <!--Using a link with a noop function will allow keyboard accessibility to toggle popover-->
-                        <a
-                            href="#"
-                            onclick="noop(event)"
-                        >...</a>
-                    </text>
-                {% endif %}
-            {% endif %}
-        </svg>
+        {% set parents = collection.parent_collections %}
+        {% set children = collection.child_collections %}
+        {% set current_item_name = collection.name %}
+        {% set current_item_id = collection.id %}
+        {% set relationship_type = "collection" %}
+        {% include "parent_child_diagram.html" %}
     </div>
     {% endif %}
 </div>
@@ -174,41 +51,14 @@
 
 {% block scripts %}
 <script>
-    document.addEventListener('DOMContentLoaded', () => {
-        const popoverTriggerEl = document.querySelector('#remaining-children-popover-trigger')
-        
-        if (!popoverTriggerEl) return
-
-        const remainingChildren = popoverTriggerEl
-            .getAttribute('data-remaining-children')
-            .split('__child|separator__')
-            .slice(0, -1);
-
-        const content = remainingChildren.map(
-            childString => {
-                const childData = childString.split("__id|name__")
-                return `
-                    <a href="${childData[0]}">
-                        ${childData[1]}
-                    </a><br>
-                `
-            }
-        )
-        new bootstrap.Popover(popoverTriggerEl, {
-            html: true,
-            content: content.join(''),
-            trigger: "click hover",
-            title: `Additional child collection${remainingChildren.length === 1 ? '' : 's'}:`,
-        })
-    })
-
     const tooltipTriggerList = [].slice.call(document.querySelectorAll('[data-bs-toggle="tooltip"]'))
     const tooltipList = tooltipTriggerList.map(function (tooltipTriggerEl) {
         return new bootstrap.Tooltip(tooltipTriggerEl)
     })
 
-    function noop(e) {
-        e.preventDefault()
-    }
+    const popoverTriggerList = [].slice.call(document.querySelectorAll('[data-bs-toggle="popover"]'))
+    const popoverList = popoverTriggerList.map(function (popoverTriggerEl) {
+        return new bootstrap.Popover(popoverTriggerEl)
+    })
 </script>
 {% endblock %}

--- a/hipposerve/web/templates/collection.html
+++ b/hipposerve/web/templates/collection.html
@@ -2,7 +2,10 @@
 {% block content %}
 <div class="container-fluid fs-base">
 <h2>{{ collection.name }}</h2>
-<span class="badge text-bg-secondary mb-1 p-2">ID: {{ collection.id }}</span>
+<div class="d-flex align-items-center gap-1">
+    <div class="rounded-circle" style="height: 12px; width: 12px; background-color: {{cmap.get(collection.id|string)}};"></div>
+    <span class="badge text-bg-secondary mb-1 p-2">ID: {{ collection.id }}</span>
+</div>
 {% markdown %}
 {{ collection.description }}
 {% endmarkdown %}

--- a/hipposerve/web/templates/collection.html
+++ b/hipposerve/web/templates/collection.html
@@ -6,23 +6,209 @@
 {% markdown %}
 {{ collection.description }}
 {% endmarkdown %}
-    <table class="table table-sm border border-secondary-subtle shadow-sm" style="max-width: 800px;">
-        <thead class="table-secondary">
-            <tr>
-                <th>Product</th>
-                <th>Uploaded</th>
-                <th>Version</th>
-            </tr>
-        </thead>
-        <tbody>
-            {% for product in collection.products %}
-            <tr class="small">
-                <td><a href='../products/{{ product.id | e}}'>{{ product.name }}</a></td>
-                <td>{{ product.uploaded.strftime('%Y-%m-%d %H:%M:%S') }}</td>
-                <td>{{ product.version }}</td>
-            </tr>
-            {% endfor %}
-        </tbody>
-    </table>
+    <div>
+        <h3>Products</h3>
+        <table class="table table-sm border border-secondary-subtle shadow-sm" style="max-width: 800px;">
+            <thead class="table-secondary">
+                <tr>
+                    <th>Product</th>
+                    <th>Uploaded</th>
+                    <th>Version</th>
+                </tr>
+            </thead>
+            <tbody>
+                {% if collection.products | length > 0 %}
+                    {% for product in collection.products %}
+                    <tr class="small">
+                        <td><a href='../products/{{ product.id | e}}'>{{ product.name }}</a></td>
+                        <td>{{ product.uploaded.strftime('%Y-%m-%d %H:%M:%S') }}</td>
+                        <td>{{ product.version }}</td>
+                    </tr>
+                    {% endfor %}
+                {% else %}
+                <tr class="small">
+                    <td class="fst-italic">No products</td>
+                    <td></td>
+                    <td></td>
+                </tr>
+                {% endif %}
+            </tbody>
+        </table>
+    </div>
+    {% if collection.parent_collections | length > 0 or collection.child_collections | length > 0 %}
+    {% set collection_dependencies = [collection.child_collections, collection.parent_collections] %}
+    <div class="row">
+        <h3>Collections</h3>
+        {% set parent_collections_t = [{"name": "parent a", "id": 100}] %}
+        {% set child_collections_t = [
+            {"name": "short", "id": 1},
+            {"name": "blah blah blah blah blah", "id": 2},
+            {"name": "this is poorly named", "id": 3},
+            {"name": "the golden child, if you will", "id": 4},
+            {"name": "child 5", "id": 5},
+            {"name": "child 6", "id": 6},
+            {"name": "child 7", "id": 7},
+        ] %}
+        {% set parent_collections = collection.parent_collections %}
+        {% set child_collections = collection.child_collections %}
+        {% set parent_length = parent_collections|length %}
+        {% set child_length = child_collections|length %}
+        {% set max_svg_width = 750 %}
+        {% set svg_width = ((parent_length if parent_length > child_length else child_length) * 125) if (parent_length < 6 and child_length < 6) else max_svg_width %}
+        {% set svg_height = 250 %}
+        {% set max_index_for_spacing = 6 %}
+        {% set y_adjustment = 0 if parent_length else 50 %}
+        <svg width="{{ svg_width }}" height="{{ svg_height }}">
+            <defs>
+                <marker 
+                  id='head' 
+                  orient="auto" 
+                  markerWidth='3' 
+                  markerHeight='4' 
+                  refX='0.1' 
+                  refY='2'
+                >
+                  <path d='M0,0 V4 L2,2 Z' fill="black" />
+                </marker>
+            </defs>
+            {% if parent_length %}
+                <!-- There can only be one parent -->
+                {% for index in range(parent_length) %}
+                    <text
+                        text-anchor="middle"
+                        x="{{ svg_width / 2 }}"
+                        y="15"
+                        data-bs-toggle="tooltip"
+                        title="{{ parent_collections[index].name }}"
+                    >
+                        <a href="../collections/{{parent_collections[index].id | e}}">{{parent_collections[index].name|truncate(11, True)}}</a>
+                    </text>
+                {% endfor %}
+                <path
+                    id='arrow-line'
+                    marker-end='url(#head)'
+                    stroke-width='2'
+                    fill='none'
+                    stroke='black'
+                    d="M{{ svg_width / 2 }},25, {{svg_width / 2}},50"
+                />
+            {% endif %}
+            <circle 
+                fill="#198754"
+                r="4"
+                cx="{{svg_width / 2 - 45}}"
+                cy="{{65 - y_adjustment}}"
+                data-bs-toggle="tooltip"
+                title="You are currently viewing this collection"
+            />
+            <text
+                text-anchor="middle"
+                x="{{ svg_width / 2 }}"
+                y="{{70 - y_adjustment }}"
+                data-bs-toggle="tooltip"
+                title="{{ collection.name }}"
+                class="fw-bold"
+                >{{collection.name|truncate(11, True)}}</text>
+            {% if child_length %}
+                {% if child_length != 1 %}
+                <path
+                    stroke-width="2"
+                    stroke="black"
+                    d="M{{ svg_width / 2 }},{{75 - y_adjustment}}, {{ svg_width / 2}},{{100 - y_adjustment}}"
+                />
+                {% endif %}
+                {% set y2_adjustment = y_adjustment if child_length > 1 else (y_adjustment + 20) %}
+                {% set dx_divisor = (max_index_for_spacing if child_length >= (max_index_for_spacing + 1) else child_length) + 1 %}
+                {% set dx_divisor_t = 7 %}
+                {% for index in range(child_length) if index <= 5 %}
+                    <path
+                        stroke-width="2"
+                        stroke="black"
+                        d="M{{ svg_width / 2 }},{{100 - y2_adjustment}} {{ ( svg_width / (dx_divisor) ) * (index + 1) }},{{100 - y2_adjustment}}"
+                    />
+                    <path
+                        id='arrow-line'
+                        marker-end='url(#head)'
+                        stroke-width='2'
+                        fill='none'
+                        stroke='black'
+                        d="M{{ ( svg_width / (dx_divisor) ) * (index + 1) }},{{99 - y2_adjustment}}, {{ ( svg_width / (dx_divisor) ) * (index + 1) }},{{120 - y2_adjustment}}"
+                    />
+                    {% if index <= 4 %}
+                        <text
+                            text-anchor="middle"
+                            x="{{ ( svg_width / (dx_divisor) ) * (index + 1) }}"
+                            y="{{140 - y2_adjustment}}"
+                            data-bs-toggle="tooltip"
+                            title="{{ child_collections[index].name }}"
+                        >
+                            <a href="../collections/{{child_collections[index].id | e}}">{{child_collections[index].name|truncate(11, True)}}</a>
+                        </text>
+                    {% endif %}
+                {% endfor %}
+                {% if child_length > 5 %}
+                    {% set remaining_children = [] %}
+                    {% for index in range(5, child_length) %}
+                        {% set _ = remaining_children.append(child_collections[index].id|e + "__id|name__" + child_collections[index].name + "__child|separator__") %}
+                    {% endfor %}
+                    <text
+                        text-anchor="middle"
+                        x="{{ ( svg_width / (dx_divisor) ) * (max_index_for_spacing) }}"
+                        y="{{140 - y2_adjustment}}"
+                        id="remaining-children-popover-trigger"
+                        data-remaining-children="{{''.join(remaining_children)}}"
+                        >
+                        <!--Using a link with a noop function will allow keyboard accessibility to toggle popover-->
+                        <a
+                            href="#"
+                            onclick="noop(event)"
+                        >...</a>
+                    </text>
+                {% endif %}
+            {% endif %}
+        </svg>
+    </div>
+    {% endif %}
 </div>
+{% endblock %}
+
+{% block scripts %}
+<script>
+    document.addEventListener('DOMContentLoaded', () => {
+        const popoverTriggerEl = document.querySelector('#remaining-children-popover-trigger')
+        
+        if (!popoverTriggerEl) return
+
+        const remainingChildren = popoverTriggerEl
+            .getAttribute('data-remaining-children')
+            .split('__child|separator__')
+            .slice(0, -1);
+
+        const content = remainingChildren.map(
+            childString => {
+                const childData = childString.split("__id|name__")
+                return `
+                    <a href="${childData[0]}">
+                        ${childData[1]}
+                    </a><br>
+                `
+            }
+        )
+        new bootstrap.Popover(popoverTriggerEl, {
+            html: true,
+            content: content.join(''),
+            trigger: "click hover",
+            title: `Additional child collection${remainingChildren.length === 1 ? '' : 's'}:`,
+        })
+    })
+
+    const tooltipTriggerList = [].slice.call(document.querySelectorAll('[data-bs-toggle="tooltip"]'))
+    const tooltipList = tooltipTriggerList.map(function (tooltipTriggerEl) {
+        return new bootstrap.Tooltip(tooltipTriggerEl)
+    })
+
+    function noop(e) {
+        e.preventDefault()
+    }
+</script>
 {% endblock %}

--- a/hipposerve/web/templates/core.html
+++ b/hipposerve/web/templates/core.html
@@ -54,6 +54,9 @@
         document.querySelector('.jump-to-top').style.display = 'none';
       }
     }
+    function noop(e) {
+        e.preventDefault()
+    }
   </script>
   <body class="position-relative small h-100 bg-light" onscroll="debounce(onScroll, 100)">
     {% include "navigation.html" %}

--- a/hipposerve/web/templates/parent_child_diagram.html
+++ b/hipposerve/web/templates/parent_child_diagram.html
@@ -1,13 +1,18 @@
 {% set parent_length = parents|length %}
 {% set child_length = children|length %}
-{% set max_items_rendered = 5 %}
-{% set max_index_for_spacing = max_items_rendered + 1 %}
-{% set max_svg_width = 750 %}
-{% set svg_width = ((parent_length if parent_length > child_length else child_length) * 125) if (parent_length <= max_items_rendered and child_length <= max_items_rendered) else max_svg_width %}
+<!-- we only render 5 items but, if necessary, we render a 6th element for overflow data -->
+{% set max_items_rendered = 6 %}
+<!-- spacing is calculated based on number of items rendered + 1 -->
+{% set max_num_of_equal_widths = max_items_rendered + 1 %}
+<!-- arbitrarily set item width at 125px -->
+{% set item_width = 125 %}
+{% set max_svg_width = max_items_rendered * item_width %}
+{% set svg_width = ((parent_length if parent_length > child_length else child_length) * item_width) if (parent_length < max_items_rendered and child_length < max_items_rendered) else max_svg_width %}
 {% set svg_height = 250 %}
 {% set y_adjustment = 0 if parent_length == 1 else (50 if parent_length < 1 else -20) %}
 <svg width="{{ svg_width }}" height="{{ svg_height }}">
     <defs>
+        <!-- define a down arrow to be used in the diagram -->
         <marker 
           id='head' 
           orient="auto" 
@@ -19,13 +24,19 @@
           <path d='M0,0 V4 L2,2 Z' fill="black" />
         </marker>
     </defs>
+
+    <!--BEGIN SVG ELEMENTS FOR PARENT(S) -->
     {% if parent_length %}
-        {% set dx_divisor = (max_index_for_spacing if parent_length >= (max_index_for_spacing + 1) else parent_length) + 1 %}
+        <!-- used to divide up the svg_width when calculating x position of items' text and lines -->
+        {% set num_of_parent_equal_widths = max_num_of_equal_widths if parent_length >= max_items_rendered else (parent_length + 1) %}
+        {% set x1 = svg_width / num_of_parent_equal_widths %}
         {% for index in range(parent_length) %}
-            {% if index < max_items_rendered %}
+            {% set x2 = x1 * (index + 1) %}
+            <!-- render links to items up until the max -->
+            {% if index < (max_items_rendered - 1) %}
                 <text
                     text-anchor="middle"
-                    x="{{ ( svg_width / (dx_divisor) ) * (index + 1) }}"
+                    x="{{x2}}"
                     y="15"
                     data-bs-toggle="tooltip"
                     title="{{ parents[index].name }}"
@@ -33,26 +44,30 @@
                     <a href="{{ web_root }}/{{relationship_type}}s/{{parents[index].id | e}}">{{parents[index].name|truncate(11, True)}}</a>
                 </text>
             {% endif %}
-            {% if parent_length > 1 and index <= max_items_rendered %}
+            <!-- with multiple parents, we need some lines to show the connection -->
+            {% if parent_length > 1 and index < max_items_rendered %}
+                <!-- draw a vertical line from the text -->
                 <path
                     stroke-width="2"
                     stroke="black"
-                    d="M{{ svg_width / 2 }},44 {{ ( svg_width / (dx_divisor) ) * (index + 1) }},44"
+                    d="M{{x2}},25, {{x2}},45"
                 />
+                <!-- draw a horizontal line that connects with the vertical line above and to neighboring horizontal line(s) -->
                 <path
                     stroke-width="2"
                     stroke="black"
-                    d="M{{ ( svg_width / (dx_divisor) ) * (index + 1) }},25, {{ ( svg_width / (dx_divisor) ) * (index + 1) }},45"
+                    d="M{{x1}},44 {{x2}},44"
                 />
             {% endif %}
         {% endfor %}
-        {% if parent_length > max_items_rendered %}
+        <!-- create the "overflow" item that renders the remaining items as links in a Bootstrap popover -->
+        {% if parent_length >= max_items_rendered %}
             <text
                 text-anchor="middle"
-                x="{{ ( svg_width / (dx_divisor) ) * (max_index_for_spacing) }}"
+                x="{{ x1 * max_items_rendered }}"
                 y="15"
                 data-bs-toggle="popover"
-                data-bs-title="Additional parent {{relationship_type}}{{'' if parent_length == (max_items_rendered + 1) else 's'}}"
+                data-bs-title="Additional parent {{relationship_type}}{{'' if parent_length == max_items_rendered else 's'}}"
                 data-bs-html="true"
                 data-bs-trigger="click hover"
                 data-bs-content="{{parents_overflow_content}}"
@@ -65,6 +80,7 @@
             </text>
         {% endif %}
         {% set y3_adjustment = 0 if parent_length == 1 else 20 %}
+        <!-- draw vertical line with down arrow pointing from parent(s) to currently-viewed item -->
         <path
             id='arrow-line'
             marker-end='url(#head)'
@@ -74,6 +90,10 @@
             d="M{{ svg_width / 2 }},{{25 + y3_adjustment}}, {{svg_width / 2}},{{50 + y3_adjustment}}"
         />
     {% endif %}
+    <!-- END -->
+
+    <!-- BEGIN SVG ELEMENTS FOR CURRENT ITEM -->
+    <!-- render a green circle next to the currently-viewed item, similar to the UI indiciating which version is being viewed -->
     <circle 
         fill="#198754"
         r="4"
@@ -82,6 +102,7 @@
         data-bs-toggle="tooltip"
         title="You are currently viewing this {{relationship_type}}"
     />
+    <!-- render text for current item -->
     <text
         text-anchor="middle"
         x="{{ svg_width / 2 }}"
@@ -90,7 +111,11 @@
         title="{{ current_item_name }}"
         class="fw-bold"
         >{{current_item_name|truncate(11, True)}}</text>
+    <!-- END -->
+
+    <!-- BEGIN SVG ELEMENTS FOR CHILD(REN) -->
     {% if child_length %}
+        <!-- draw vertical line from current item's text that will connect to the horizontal line used to connect children -->
         {% if child_length != 1 %}
         <path
             stroke-width="2"
@@ -98,26 +123,35 @@
             d="M{{ svg_width / 2 }},{{75 - y_adjustment}}, {{ svg_width / 2}},{{100 - y_adjustment}}"
         />
         {% endif %}
+        <!-- set a y adjustment based on whether or not the vertical line above is present -->
         {% set y2_adjustment = y_adjustment if child_length > 1 else (y_adjustment + 20) %}
-        {% set dx_divisor = (max_index_for_spacing if child_length >= (max_index_for_spacing + 1) else child_length) + 1 %}
-        {% for index in range(child_length) if index <= max_items_rendered %}
+        <!-- used to divide up the svg_width when calculating x position of items' text and lines -->
+        {% set num_of_child_equal_widths = max_num_of_equal_widths if child_length >= max_items_rendered else (child_length + 1) %}
+        {% set x1 = svg_width / num_of_child_equal_widths %}
+        {% for index in range(child_length) %}
+            {% set x2 = x1 * (index + 1) %}
+            {% if child_length > 1 and index < max_items_rendered %}
+            <!-- draw a horizontal line that connects with the vertical line above and to neighboring horizontal line(s) -->
             <path
                 stroke-width="2"
                 stroke="black"
-                d="M{{ svg_width / 2 }},{{100 - y2_adjustment}} {{ ( svg_width / (dx_divisor) ) * (index + 1) }},{{100 - y2_adjustment}}"
+                d="M{{x1}},{{100 - y2_adjustment}} {{x2}},{{100 - y2_adjustment}}"
             />
+            <!-- draw a vertical line with down arrow from the horizontal line to each item's text -->
             <path
                 id='arrow-line'
                 marker-end='url(#head)'
                 stroke-width='2'
                 fill='none'
                 stroke='black'
-                d="M{{ ( svg_width / (dx_divisor) ) * (index + 1) }},{{99 - y2_adjustment}}, {{ ( svg_width / (dx_divisor) ) * (index + 1) }},{{120 - y2_adjustment}}"
+                d="M{{x2}},{{99 - y2_adjustment}}, {{x2}},{{120 - y2_adjustment}}"
             />
-            {% if index <= max_items_rendered - 1 %}
+            {% endif %}
+            <!-- render links to items up until the max -->
+            {% if index < (max_items_rendered - 1) %}
                 <text
                     text-anchor="middle"
-                    x="{{ ( svg_width / (dx_divisor) ) * (index + 1) }}"
+                    x="{{x2}}"
                     y="{{140 - y2_adjustment}}"
                     data-bs-toggle="tooltip"
                     title="{{ children[index].name }}"
@@ -126,13 +160,14 @@
                 </text>
             {% endif %}
         {% endfor %}
-        {% if child_length > max_items_rendered %}
+        <!-- create the "overflow" item that renders the remaining items as links in a Bootstrap popover -->
+        {% if child_length >= max_items_rendered %}
             <text
                 text-anchor="middle"
-                x="{{ ( svg_width / (dx_divisor) ) * (max_index_for_spacing) }}"
+                x="{{ x1 * max_items_rendered }}"
                 y="{{140 - y2_adjustment}}"
                 data-bs-toggle="popover"
-                data-bs-title="Additional child {{relationship_type}}{{'' if child_length == (max_items_rendered + 1) else 's'}}"
+                data-bs-title="Additional child {{relationship_type}}{{'' if child_length == max_items_rendered else 's'}}"
                 data-bs-html="true"
                 data-bs-trigger="click hover"
                 data-bs-content="{{children_overflow_content}}"
@@ -145,4 +180,5 @@
             </text>
         {% endif %}
     {% endif %}
+    <!-- END -->
 </svg>

--- a/hipposerve/web/templates/parent_child_diagram.html
+++ b/hipposerve/web/templates/parent_child_diagram.html
@@ -3,41 +3,49 @@
 <!-- we only render 5 items but, if necessary, we render a 6th element for overflow data -->
 {% set max_items_rendered = 6 %}
 <!-- spacing is calculated based on number of items rendered + 1 -->
-{% set max_num_of_equal_widths = max_items_rendered + 1 %}
+{% set max_num_of_equal_spacing = max_items_rendered + 1 %}
 <!-- arbitrarily set item width at 125px -->
-{% set item_width = 125 %}
-{% set max_svg_width = max_items_rendered * item_width %}
-{% set svg_width = ((parent_length if parent_length > child_length else child_length) * item_width) if (parent_length < max_items_rendered and child_length < max_items_rendered) else max_svg_width %}
-{% set svg_height = 250 %}
-{% set y_adjustment = 0 if parent_length == 1 else (50 if parent_length < 1 else -20) %}
-<svg width="{{ svg_width }}" height="{{ svg_height }}">
+{% set item_height = 40 %}
+{% set max_svg_height = max_items_rendered * item_height %}
+{% set svg_width = 250 %}
+{% set svg_height = ((parent_length if parent_length > child_length else child_length) * item_height) if (parent_length < max_items_rendered and child_length < max_items_rendered) else max_svg_height %}
+{% set item_width = 95 %}
+{% set horizontal_line_length = 20 %}
+{% set parent_x_adjustment = -1 * item_width if parent_length == 0 else item_width %}
+{% set x_margin = 10 %}
+{% set x_adjustment = parent_x_adjustment + x_margin %}
+{% set text_item_padding = 10 %}
+{% set line_y_centering_adjustment = 5 %}
+<svg width="{{ svg_width }}" height="{{ svg_height }}" class="font-monospace">
     <defs>
         <!-- define a down arrow to be used in the diagram -->
         <marker 
           id='head' 
           orient="auto" 
-          markerWidth='3' 
-          markerHeight='4' 
-          refX='0.1' 
-          refY='2'
+          markerWidth='4' 
+          markerHeight='4'
+          refX='0'
+          refY='0'
         >
-          <path d='M0,0 V4 L2,2 Z' fill="black" />
+          <circle 
+              fill="#198754"
+              r="2.5"
+          />
         </marker>
     </defs>
 
     <!--BEGIN SVG ELEMENTS FOR PARENT(S) -->
     {% if parent_length %}
-        <!-- used to divide up the svg_width when calculating x position of items' text and lines -->
-        {% set num_of_parent_equal_widths = max_num_of_equal_widths if parent_length >= max_items_rendered else (parent_length + 1) %}
-        {% set x1 = svg_width / num_of_parent_equal_widths %}
+        <!-- used to divide up the svg_height when calculating y position of items' text and lines -->
+        {% set num_of_parent_equal_spaces = max_num_of_equal_spacing if parent_length >= max_items_rendered else (parent_length + 1) %}
+        {% set y1 = svg_height / num_of_parent_equal_spaces %}
         {% for index in range(parent_length) %}
-            {% set x2 = x1 * (index + 1) %}
+            {% set y2 = y1 * (index + 1) %}
             <!-- render links to items up until the max -->
             {% if index < (max_items_rendered - 1) %}
                 <text
-                    text-anchor="middle"
-                    x="{{x2}}"
-                    y="15"
+                    x="{{x_margin}}"
+                    y="{{y2}}"
                     data-bs-toggle="tooltip"
                     title="{{ parents[index].name }}"
                 >
@@ -46,26 +54,27 @@
             {% endif %}
             <!-- with multiple parents, we need some lines to show the connection -->
             {% if parent_length > 1 and index < max_items_rendered %}
-                <!-- draw a vertical line from the text -->
+                <!-- draw a horizontal line from parents to the the vertical line connecting the parents -->
                 <path
                     stroke-width="2"
                     stroke="black"
-                    d="M{{x2}},25, {{x2}},45"
+                    d="M{{x_adjustment + text_item_padding}},{{y2 - line_y_centering_adjustment}} 
+                    {{x_adjustment + text_item_padding + horizontal_line_length + 1}},{{y2 - line_y_centering_adjustment}}"
                 />
-                <!-- draw a horizontal line that connects with the vertical line above and to neighboring horizontal line(s) -->
+                <!-- draw a vertical line that connects to each parent's horizontal line -->
                 <path
                     stroke-width="2"
                     stroke="black"
-                    d="M{{x1}},44 {{x2}},44"
+                    d="M{{x_adjustment + horizontal_line_length + text_item_padding}},{{y1 - line_y_centering_adjustment}} 
+                    {{x_adjustment + horizontal_line_length + text_item_padding}},{{y2 - line_y_centering_adjustment}}"
                 />
             {% endif %}
         {% endfor %}
         <!-- create the "overflow" item that renders the remaining items as links in a Bootstrap popover -->
         {% if parent_length >= max_items_rendered %}
             <text
-                text-anchor="middle"
-                x="{{ x1 * max_items_rendered }}"
-                y="15"
+                x="{{x_margin}}"
+                y="{{ y1 * max_items_rendered }}"
                 data-bs-toggle="popover"
                 data-bs-title="Additional parent {{relationship_type}}{{'' if parent_length == max_items_rendered else 's'}}"
                 data-bs-html="true"
@@ -79,80 +88,71 @@
                 >...</a>
             </text>
         {% endif %}
-        {% set y3_adjustment = 0 if parent_length == 1 else 20 %}
-        <!-- draw vertical line with down arrow pointing from parent(s) to currently-viewed item -->
-        <path
-            id='arrow-line'
-            marker-end='url(#head)'
-            stroke-width='2'
-            fill='none'
-            stroke='black'
-            d="M{{ svg_width / 2 }},{{25 + y3_adjustment}}, {{svg_width / 2}},{{50 + y3_adjustment}}"
-        />
     {% endif %}
     <!-- END -->
 
     <!-- BEGIN SVG ELEMENTS FOR CURRENT ITEM -->
-    <!-- render a green circle next to the currently-viewed item, similar to the UI indiciating which version is being viewed -->
-    <circle 
-        fill="#198754"
-        r="4"
-        cx="{{svg_width / 2 - 45}}"
-        cy="{{65 - y_adjustment}}"
-        data-bs-toggle="tooltip"
-        title="You are currently viewing this {{relationship_type}}"
-    />
+    {% set current_item_starting_x_position = x_margin if parent_length == 0 else (x_margin + item_width + (2 * horizontal_line_length) + (2 * text_item_padding)) %}
+    {% set parent_to_current_line_length = (horizontal_line_length * 2) if parent_length == 1 else horizontal_line_length %}
+    <!-- render line from parent to current item if necessary -->
+    {% if parent_length %}
+        <path
+            stroke-width='2'
+            stroke='black'
+            d="M{{current_item_starting_x_position - text_item_padding}},{{svg_height / 2 - line_y_centering_adjustment}} 
+            {{current_item_starting_x_position - parent_to_current_line_length - text_item_padding}},{{svg_height / 2 - line_y_centering_adjustment}}"
+        />
+    {% endif %}
     <!-- render text for current item -->
     <text
-        text-anchor="middle"
-        x="{{ svg_width / 2 }}"
-        y="{{70 - y_adjustment }}"
+        x="{{ current_item_starting_x_position }}"
+        y="{{ svg_height / 2 }}"
         data-bs-toggle="tooltip"
         title="{{ current_item_name }}"
         class="fw-bold"
         >{{current_item_name|truncate(11, True)}}</text>
+    <!-- render line from current item to child(ren) if necessary -->
+    {% if child_length %}
+        {% set current_to_children_line_length = (horizontal_line_length * 2) if child_length == 1 else horizontal_line_length %}
+        <path
+            stroke-width='2'
+            stroke='black'
+            d="M{{current_item_starting_x_position + item_width + text_item_padding}},{{svg_height / 2 - line_y_centering_adjustment}}
+            {{current_item_starting_x_position + item_width + current_to_children_line_length + text_item_padding}},{{svg_height / 2 - line_y_centering_adjustment}}"
+        />
+    {% endif %}
     <!-- END -->
 
     <!-- BEGIN SVG ELEMENTS FOR CHILD(REN) -->
     {% if child_length %}
-        <!-- draw vertical line from current item's text that will connect to the horizontal line used to connect children -->
-        {% if child_length != 1 %}
-        <path
-            stroke-width="2"
-            stroke="black"
-            d="M{{ svg_width / 2 }},{{75 - y_adjustment}}, {{ svg_width / 2}},{{100 - y_adjustment}}"
-        />
-        {% endif %}
-        <!-- set a y adjustment based on whether or not the vertical line above is present -->
-        {% set y2_adjustment = y_adjustment if child_length > 1 else (y_adjustment + 20) %}
-        <!-- used to divide up the svg_width when calculating x position of items' text and lines -->
-        {% set num_of_child_equal_widths = max_num_of_equal_widths if child_length >= max_items_rendered else (child_length + 1) %}
-        {% set x1 = svg_width / num_of_child_equal_widths %}
+        {% set section_width_with_lines = item_width + (2 * horizontal_line_length) + (2 * text_item_padding) %}
+        {% set child_starting_x_position = x_margin + (section_width_with_lines if parent_length == 0 else (2 * section_width_with_lines)) - horizontal_line_length - text_item_padding %}
+        <!-- used to divide up the svg_height when calculating y position of items' text and lines -->
+        {% set num_of_child_equal_spaces = max_num_of_equal_spacing if child_length >= max_items_rendered else (child_length + 1) %}
+        {% set y1 = svg_height / num_of_child_equal_spaces %}
         {% for index in range(child_length) %}
-            {% set x2 = x1 * (index + 1) %}
+            {% set y2 = y1 * (index + 1) %}
             {% if child_length > 1 and index < max_items_rendered %}
-            <!-- draw a horizontal line that connects with the vertical line above and to neighboring horizontal line(s) -->
-            <path
-                stroke-width="2"
-                stroke="black"
-                d="M{{x1}},{{100 - y2_adjustment}} {{x2}},{{100 - y2_adjustment}}"
-            />
-            <!-- draw a vertical line with down arrow from the horizontal line to each item's text -->
-            <path
-                id='arrow-line'
-                marker-end='url(#head)'
-                stroke-width='2'
-                fill='none'
-                stroke='black'
-                d="M{{x2}},{{99 - y2_adjustment}}, {{x2}},{{120 - y2_adjustment}}"
-            />
+                <!-- draw a horizontal line from the vertical line to each child text -->
+                <path
+                    stroke-width='2'
+                    stroke='black'
+                    d="M{{child_starting_x_position - 1}},{{y2 - line_y_centering_adjustment}} 
+                    {{child_starting_x_position + horizontal_line_length}},{{y2 - line_y_centering_adjustment}}"
+                />
+                <!-- draw a vertical line that connects to the horizontal lines of each child -->
+                <path
+                    stroke-width="2"
+                    stroke="black"
+                    d="M{{child_starting_x_position}},{{y1 - line_y_centering_adjustment}} 
+                    {{child_starting_x_position}},{{y2 - line_y_centering_adjustment}}"
+                />
             {% endif %}
             <!-- render links to items up until the max -->
             {% if index < (max_items_rendered - 1) %}
                 <text
-                    text-anchor="middle"
-                    x="{{x2}}"
-                    y="{{140 - y2_adjustment}}"
+                    x="{{child_starting_x_position + horizontal_line_length + text_item_padding}}"
+                    y="{{y2}}"
                     data-bs-toggle="tooltip"
                     title="{{ children[index].name }}"
                 >
@@ -163,9 +163,8 @@
         <!-- create the "overflow" item that renders the remaining items as links in a Bootstrap popover -->
         {% if child_length >= max_items_rendered %}
             <text
-                text-anchor="middle"
-                x="{{ x1 * max_items_rendered }}"
-                y="{{140 - y2_adjustment}}"
+                x="{{child_starting_x_position + horizontal_line_length}}"
+                y="{{ y1 * max_items_rendered }}"
                 data-bs-toggle="popover"
                 data-bs-title="Additional child {{relationship_type}}{{'' if child_length == max_items_rendered else 's'}}"
                 data-bs-html="true"

--- a/hipposerve/web/templates/parent_child_diagram.html
+++ b/hipposerve/web/templates/parent_child_diagram.html
@@ -1,0 +1,148 @@
+{% set parent_length = parents|length %}
+{% set child_length = children|length %}
+{% set max_items_rendered = 5 %}
+{% set max_index_for_spacing = max_items_rendered + 1 %}
+{% set max_svg_width = 750 %}
+{% set svg_width = ((parent_length if parent_length > child_length else child_length) * 125) if (parent_length <= max_items_rendered and child_length <= max_items_rendered) else max_svg_width %}
+{% set svg_height = 250 %}
+{% set y_adjustment = 0 if parent_length == 1 else (50 if parent_length < 1 else -20) %}
+<svg width="{{ svg_width }}" height="{{ svg_height }}">
+    <defs>
+        <marker 
+          id='head' 
+          orient="auto" 
+          markerWidth='3' 
+          markerHeight='4' 
+          refX='0.1' 
+          refY='2'
+        >
+          <path d='M0,0 V4 L2,2 Z' fill="black" />
+        </marker>
+    </defs>
+    {% if parent_length %}
+        {% set dx_divisor = (max_index_for_spacing if parent_length >= (max_index_for_spacing + 1) else parent_length) + 1 %}
+        {% for index in range(parent_length) %}
+            {% if index < max_items_rendered %}
+                <text
+                    text-anchor="middle"
+                    x="{{ ( svg_width / (dx_divisor) ) * (index + 1) }}"
+                    y="15"
+                    data-bs-toggle="tooltip"
+                    title="{{ parents[index].name }}"
+                >
+                    <a href="{{ web_root }}/{{relationship_type}}s/{{parents[index].id | e}}">{{parents[index].name|truncate(11, True)}}</a>
+                </text>
+            {% endif %}
+            {% if parent_length > 1 and index <= max_items_rendered %}
+                <path
+                    stroke-width="2"
+                    stroke="black"
+                    d="M{{ svg_width / 2 }},44 {{ ( svg_width / (dx_divisor) ) * (index + 1) }},44"
+                />
+                <path
+                    stroke-width="2"
+                    stroke="black"
+                    d="M{{ ( svg_width / (dx_divisor) ) * (index + 1) }},25, {{ ( svg_width / (dx_divisor) ) * (index + 1) }},45"
+                />
+            {% endif %}
+        {% endfor %}
+        {% if parent_length > max_items_rendered %}
+            <text
+                text-anchor="middle"
+                x="{{ ( svg_width / (dx_divisor) ) * (max_index_for_spacing) }}"
+                y="15"
+                data-bs-toggle="popover"
+                data-bs-title="Additional parent {{relationship_type}}{{'' if parent_length == (max_items_rendered + 1) else 's'}}"
+                data-bs-html="true"
+                data-bs-trigger="click hover"
+                data-bs-content="{{parents_overflow_content}}"
+            >
+                <!--Using a link with a noop function will allow keyboard accessibility to toggle popover-->
+                <a
+                    href="#"
+                    onclick="noop(event)"
+                >...</a>
+            </text>
+        {% endif %}
+        {% set y3_adjustment = 0 if parent_length == 1 else 20 %}
+        <path
+            id='arrow-line'
+            marker-end='url(#head)'
+            stroke-width='2'
+            fill='none'
+            stroke='black'
+            d="M{{ svg_width / 2 }},{{25 + y3_adjustment}}, {{svg_width / 2}},{{50 + y3_adjustment}}"
+        />
+    {% endif %}
+    <circle 
+        fill="#198754"
+        r="4"
+        cx="{{svg_width / 2 - 45}}"
+        cy="{{65 - y_adjustment}}"
+        data-bs-toggle="tooltip"
+        title="You are currently viewing this {{relationship_type}}"
+    />
+    <text
+        text-anchor="middle"
+        x="{{ svg_width / 2 }}"
+        y="{{70 - y_adjustment }}"
+        data-bs-toggle="tooltip"
+        title="{{ current_item_name }}"
+        class="fw-bold"
+        >{{current_item_name|truncate(11, True)}}</text>
+    {% if child_length %}
+        {% if child_length != 1 %}
+        <path
+            stroke-width="2"
+            stroke="black"
+            d="M{{ svg_width / 2 }},{{75 - y_adjustment}}, {{ svg_width / 2}},{{100 - y_adjustment}}"
+        />
+        {% endif %}
+        {% set y2_adjustment = y_adjustment if child_length > 1 else (y_adjustment + 20) %}
+        {% set dx_divisor = (max_index_for_spacing if child_length >= (max_index_for_spacing + 1) else child_length) + 1 %}
+        {% for index in range(child_length) if index <= max_items_rendered %}
+            <path
+                stroke-width="2"
+                stroke="black"
+                d="M{{ svg_width / 2 }},{{100 - y2_adjustment}} {{ ( svg_width / (dx_divisor) ) * (index + 1) }},{{100 - y2_adjustment}}"
+            />
+            <path
+                id='arrow-line'
+                marker-end='url(#head)'
+                stroke-width='2'
+                fill='none'
+                stroke='black'
+                d="M{{ ( svg_width / (dx_divisor) ) * (index + 1) }},{{99 - y2_adjustment}}, {{ ( svg_width / (dx_divisor) ) * (index + 1) }},{{120 - y2_adjustment}}"
+            />
+            {% if index <= max_items_rendered - 1 %}
+                <text
+                    text-anchor="middle"
+                    x="{{ ( svg_width / (dx_divisor) ) * (index + 1) }}"
+                    y="{{140 - y2_adjustment}}"
+                    data-bs-toggle="tooltip"
+                    title="{{ children[index].name }}"
+                >
+                    <a href="{{ web_root }}/{{relationship_type}}s/{{children[index].id | e}}">{{children[index].name|truncate(11, True)}}</a>
+                </text>
+            {% endif %}
+        {% endfor %}
+        {% if child_length > max_items_rendered %}
+            <text
+                text-anchor="middle"
+                x="{{ ( svg_width / (dx_divisor) ) * (max_index_for_spacing) }}"
+                y="{{140 - y2_adjustment}}"
+                data-bs-toggle="popover"
+                data-bs-title="Additional child {{relationship_type}}{{'' if child_length == (max_items_rendered + 1) else 's'}}"
+                data-bs-html="true"
+                data-bs-trigger="click hover"
+                data-bs-content="{{children_overflow_content}}"
+            >
+                <!--Using a link with a noop function will allow keyboard accessibility to toggle popover-->
+                <a
+                    href="#"
+                    onclick="noop(event)"
+                >...</a>
+            </text>
+        {% endif %}
+    {% endif %}
+</svg>

--- a/hipposerve/web/templates/parent_child_diagram.html
+++ b/hipposerve/web/templates/parent_child_diagram.html
@@ -4,36 +4,20 @@
 {% set max_items_rendered = 6 %}
 <!-- spacing is calculated based on number of items rendered + 1 -->
 {% set max_num_of_equal_spacing = max_items_rendered + 1 %}
-<!-- arbitrarily set item width at 125px -->
+<!-- arbitrarily set item height at 40px -->
 {% set item_height = 40 %}
 {% set max_svg_height = max_items_rendered * item_height %}
-{% set svg_width = 250 %}
+{% set svg_width = 300 %}
 {% set svg_height = ((parent_length if parent_length > child_length else child_length) * item_height) if (parent_length < max_items_rendered and child_length < max_items_rendered) else max_svg_height %}
 {% set item_width = 95 %}
 {% set horizontal_line_length = 20 %}
 {% set parent_x_adjustment = -1 * item_width if parent_length == 0 else item_width %}
 {% set x_margin = 10 %}
 {% set x_adjustment = parent_x_adjustment + x_margin %}
-{% set text_item_padding = 10 %}
+{% set text_item_padding = 15 %}
 {% set line_y_centering_adjustment = 5 %}
+{% set circle_radius = 5 %}
 <svg width="{{ svg_width }}" height="{{ svg_height }}" class="font-monospace">
-    <defs>
-        <!-- define a down arrow to be used in the diagram -->
-        <marker 
-          id='head' 
-          orient="auto" 
-          markerWidth='4' 
-          markerHeight='4'
-          refX='0'
-          refY='0'
-        >
-          <circle 
-              fill="#198754"
-              r="2.5"
-          />
-        </marker>
-    </defs>
-
     <!--BEGIN SVG ELEMENTS FOR PARENT(S) -->
     {% if parent_length %}
         <!-- used to divide up the svg_height when calculating y position of items' text and lines -->
@@ -54,6 +38,12 @@
             {% endif %}
             <!-- with multiple parents, we need some lines to show the connection -->
             {% if parent_length > 1 and index < max_items_rendered %}
+                <circle 
+                    r="{{circle_radius}}"
+                    cx="{{x_adjustment + text_item_padding}}"
+                    cy="{{y2 - line_y_centering_adjustment}}"
+                    fill="{{cmap.get(parents[index].id|string, '#000000')}}"
+                />
                 <!-- draw a horizontal line from parents to the the vertical line connecting the parents -->
                 <path
                     stroke-width="2"
@@ -88,6 +78,14 @@
                 >...</a>
             </text>
         {% endif %}
+        {% if parent_length == 1 %}
+        <circle
+            r="{{circle_radius}}"
+            cx="{{x_adjustment + text_item_padding}}"
+            cy="{{svg_height / 2 - line_y_centering_adjustment}}"
+            fill="{{cmap.get(parents[0].id|string, '#000000')}}"
+        />
+        {% endif %}
     {% endif %}
     <!-- END -->
 
@@ -96,6 +94,12 @@
     {% set parent_to_current_line_length = (horizontal_line_length * 2) if parent_length == 1 else horizontal_line_length %}
     <!-- render line from parent to current item if necessary -->
     {% if parent_length %}
+        <circle
+            r="{{circle_radius}}"
+            cx="{{current_item_starting_x_position - text_item_padding}}"
+            cy="{{svg_height / 2 - line_y_centering_adjustment}}"
+            fill="{{cmap.get(current_item_id|string, '#000000')}}"
+        />
         <path
             stroke-width='2'
             stroke='black'
@@ -114,6 +118,12 @@
     <!-- render line from current item to child(ren) if necessary -->
     {% if child_length %}
         {% set current_to_children_line_length = (horizontal_line_length * 2) if child_length == 1 else horizontal_line_length %}
+        <circle
+            r="{{circle_radius}}"
+            cx="{{current_item_starting_x_position + item_width + text_item_padding}}"
+            cy="{{svg_height / 2 - line_y_centering_adjustment}}"
+            fill="{{cmap.get(current_item_id|string, '#000000')}}"
+        />
         <path
             stroke-width='2'
             stroke='black'
@@ -133,6 +143,12 @@
         {% for index in range(child_length) %}
             {% set y2 = y1 * (index + 1) %}
             {% if child_length > 1 and index < max_items_rendered %}
+                <circle
+                    r="{{circle_radius}}"
+                    cx="{{child_starting_x_position + horizontal_line_length}}"
+                    cy="{{y2 - line_y_centering_adjustment}}"
+                    fill="{{cmap.get(children[index].id|string, '#000000')}}"
+                />
                 <!-- draw a horizontal line from the vertical line to each child text -->
                 <path
                     stroke-width='2'
@@ -163,7 +179,7 @@
         <!-- create the "overflow" item that renders the remaining items as links in a Bootstrap popover -->
         {% if child_length >= max_items_rendered %}
             <text
-                x="{{child_starting_x_position + horizontal_line_length}}"
+                x="{{child_starting_x_position + horizontal_line_length + text_item_padding}}"
                 y="{{ y1 * max_items_rendered }}"
                 data-bs-toggle="popover"
                 data-bs-title="Additional child {{relationship_type}}{{'' if child_length == max_items_rendered else 's'}}"
@@ -177,6 +193,14 @@
                     onclick="noop(event)"
                 >...</a>
             </text>
+        {% endif %}
+        {% if child_length == 1 %}
+            <circle
+                r="{{circle_radius}}"
+                cx="{{child_starting_x_position + horizontal_line_length}}"
+                cy="{{svg_height / 2 - line_y_centering_adjustment}}"
+                fill="{{cmap.get(children[0].id|string, '#000000')}}"
+            />
         {% endif %}
     {% endif %}
     <!-- END -->


### PR DESCRIPTION
This branch creates a `parent_child_diagram.html` template that uses a list of parents and a list of children to create a diagram of the relationship. The template should allow us to extend it to the product relationships as well, though we will likely need to handle sizing and position issues.

I made updates to the `examples/recursive_collection/simplepopulate.py` script such that we can see/test varying parent-child relationships.